### PR TITLE
Support for SSL access to FreeNAS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Please be aware that this enhancment uses the FreeNAS APIs and NOT the ssh/scp l
 1. Execute the following at a console command prompt to active the above
     ```bash
     systemctl restart pvedaemon
+    systemctl restart pveproxy
+    systemctl restart pvestatd
     ```
 
 1. Refresh the Proxmox GUI in your browser to load the new Javascript code. 

--- a/perl5/PVE/Storage/ZFSPlugin.pm.patch
+++ b/perl5/PVE/Storage/ZFSPlugin.pm.patch
@@ -35,7 +35,7 @@
          } elsif ($scfg->{iscsiprovider} eq 'istgt') {
              $msg = PVE::Storage::LunCmd::Istgt::run_lun_command($scfg, $timeout, $method, @params);
          } elsif ($scfg->{iscsiprovider} eq 'iet') {
-@@ -173,6 +178,14 @@
+@@ -173,6 +178,18 @@
  	    description => "iscsi provider",
  	    type => 'string',
  	},
@@ -47,15 +47,20 @@
 +	    description => "FreeNAS API Password",
 +	    type => 'string',
 +	},
++	freenas_use_ssl => {
++	    description => "FreeNAS API access via SSL",
++	    type => 'boolean',
++	},
  	# this will disable write caching on comstar and istgt.
  	# it is not implemented for iet. iet blockio always operates with
  	# writethrough caching when not in readonly mode
-@@ -204,6 +217,8 @@
+@@ -204,6 +221,9 @@
  	sparse => { optional => 1 },
  	comstar_hg => { optional => 1 },
  	comstar_tg => { optional => 1 },
 +	freenas_user => { optional => 1 },
 +	freenas_password => { optional => 1 },
++	freenas_use_ssl => { optional => 1 },
  	content => { optional => 1 },
  	bwlimit => { optional => 1 },
      };

--- a/pve-docs/api-viewer/apidoc.js.patch
+++ b/pve-docs/api-viewer/apidoc.js.patch
@@ -1,6 +1,6 @@
 --- /usr/share/pve-docs/api-viewer/apidoc.js.orig	2018-06-04 12:08:17.416780601 +0800
 +++ /usr/share/pve-docs/api-viewer/apidoc.js	2018-06-04 12:07:28.073832212 +0800
-@@ -27549,6 +27549,18 @@
+@@ -27549,6 +27549,24 @@
                             "type" : "string",
                             "typetext" : "<string>"
                          },
@@ -16,14 +16,19 @@
 +                           "type" : "string",
 +                           "typetext" : "<string>"
 +                        },
++                        "freenas_use_ssl" : {
++                           "description" : "FreeNAS API access via SSL",
++                           "optional" : 1,
++                           "type" : "boolean",
++                           "typetext" : "<boolean>"
++                        },
                          "content" : {
                             "description" : "Allowed content types.\n\nNOTE: the value 'rootdir' is used for Containers, and value 'images' for VMs.\n",
                             "format" : "pve-storage-content-list",
-@@ -27895,6 +27907,18 @@
-                      "optional" : 1,
+@@ -27896,6 +27914,24 @@
                       "type" : "string",
                       "typetext" : "<string>"
-+                  },
+                   },
 +                  "freenas_user" : {
 +                     "description" : "FreeNAS user for API calls",
 +                     "optional" : 1,
@@ -35,6 +40,13 @@
 +                     "optional" : 1,
 +                     "type" : "string",
 +                     "typetext" : "<string>"
-                   },
++                  },
++                  "freenas_use_ssl" : {
++                     "description" : "FreeNAS API access via SSL",
++                     "optional" : 1,
++                     "type" : "boolean",
++                     "typetext" : "<boolean>"
++                  },
                    "content" : {
                       "description" : "Allowed content types.\n\nNOTE: the value 'rootdir' is used for Containers, and value 'images' for VMs.\n",
+                      "format" : "pve-storage-content-list",

--- a/pve-manager/js/pvemanagerlib.js.patch
+++ b/pve-manager/js/pvemanagerlib.js.patch
@@ -8,7 +8,7 @@
  	[ 'istgt', 'istgt'],
  	[ 'iet', 'IET']
      ]
-@@ -27343,6 +27344,13 @@
+@@ -27343,6 +27344,27 @@
  		value: '',
  		fieldLabel: gettext('Target group'),
  		allowBlank: true
@@ -19,13 +19,6 @@
 +		value: '',
 +		fieldLabel: gettext('FreeNAS User'),
 +		allowBlank: true
- 	    }
- 	];
- 
-@@ -27374,6 +27382,13 @@
- 		value: '',
- 		fieldLabel: gettext('Host group'),
- 		allowBlank: true
 +	    },
 +	    {
 +		xtype: me.isCreate ? 'textfield' : 'displayfield',
@@ -33,6 +26,13 @@
 +		value: '',
 +		fieldLabel: gettext('FreeNAS Password'),
 +		allowBlank: true
++	    },
++	    {
++		xtype: 'proxmoxcheckbox',
++		name: 'freenas_use_ssl',
++		checked: false,
++		uncheckedValue: 0,
++		fieldLabel: gettext('FreeNAS API use SSL')
  	    }
  	];
  

--- a/pve-manager/js/pvemanagerlib.js.patch
+++ b/pve-manager/js/pvemanagerlib.js.patch
@@ -1,6 +1,6 @@
 --- /usr/share/pve-manager/js/pvemanagerlib.js.orig	2018-06-04 11:21:26.419121310 +0800
 +++ /usr/share/pve-manager/js/pvemanagerlib.js	2018-06-04 11:52:58.628592707 +0800
-@@ -5303,6 +5303,7 @@
+@@ -5356,6 +5356,7 @@
      alias: ['widget.pveiScsiProviderSelector'],
      comboItems: [
  	['comstar', 'Comstar'],
@@ -8,7 +8,7 @@
  	[ 'istgt', 'istgt'],
  	[ 'iet', 'IET']
      ]
-@@ -27145,6 +27146,13 @@
+@@ -27343,6 +27344,13 @@
  		value: '',
  		fieldLabel: gettext('Target group'),
  		allowBlank: true
@@ -22,7 +22,7 @@
  	    }
  	];
  
-@@ -27176,6 +27184,13 @@
+@@ -27374,6 +27382,13 @@
  		value: '',
  		fieldLabel: gettext('Host group'),
  		allowBlank: true


### PR DESCRIPTION
I've prepared some patches to fix issues I found:

- I've added support for SSL connections to FreeNAS API.
I've got some problems with configuring connection with FreeNAS because I've got no http access to it at all. So, I've added new option freenas_use_ssl in storage configuration - when active, FreeNAS plugin uses https:// URI scheme. I've disabled SSL certificate verification, because connection to FreeNAS is usually by IP address.

- I've updated README with information about `pveproxy` and `pvestatd` restart.
I've noticed following error generated by `pveproxy` and `pvestatd` daemons in my syslog:
   ```
   Jul 11 12:47:04 node-2 pvestatd[21034]: file /etc/pve/storage.cfg line 8 (section 'freenas-zfs') - unable to parse value of 'freenas_password': unexpected property 'freenas_password'
   Jul 11 12:47:04 node-2 pvestatd[21034]: file /etc/pve/storage.cfg line 10 (section 'freenas-zfs') - unable to parse value of 'freenas_user': unexpected property 'freenas_user'
   ```
   Restarting all daemons seems to fix that issue.