### PR TITLE
Adds a function to return NAA

### DIFF
--- a/perl5/PVE/Storage/LunCmd/FreeNAS.pm
+++ b/perl5/PVE/Storage/LunCmd/FreeNAS.pm
@@ -52,6 +52,9 @@ sub run_lun_command {
     if($method eq "list_view") {
         return run_list_view($scfg, $timeout, $method, @params);
     }
+    if($method eq "list_extent") {
+        return run_list_extent($scfg, $timeout, $method, @params);
+    }
     if($method eq "list_lu") {
         return run_list_lu($scfg, $timeout, $method, "name", @params);
     }
@@ -104,6 +107,29 @@ sub run_list_lu {
     }
     if(!defined($result)) {
       syslog("info","FreeNAS::list_lu($object):$result_value_type : lun not found");
+    }
+
+    return $result;
+}
+
+#
+#
+#
+sub run_list_extent {
+    my ($scfg, $timeout, $method, @params) = @_;
+    my $object = $params[0];
+    my $result = undef;
+
+    my $luns = freenas_list_lu($scfg);
+    foreach my $lun (@$luns) {
+        if ($lun->{'iscsi_target_extent_path'} =~ /^$object$/) {
+            $result = $lun->{'iscsi_target_extent_naa'};
+            syslog("info","FreeNAS::list_extent($object): naa found $result");
+            last;
+        }
+    }
+    if(!defined($result)) {
+      syslog("info","FreeNAS::list_extent($object): naa not found");
     }
 
     return $result;


### PR DESCRIPTION
As the ZFSPlugin.pm is a patch, I am only comfortable adding the required functionality for the FreeNAS side.

All this basically does is find and return the NAA which is the WWID. This maps directly to the multipathed device.

I have attached my copy of ZFSPlugin.pm that can be used to create the required patch. As the changes are only applicable if they are using multipath, there needs to be some work to feature gate this and probably ensure that the shell commands run properly and return an error if they don't.

We also found that the sleep was needed when creating the UEFI disk. Starting a VM didn't need it.
I don't know if calling refresh is required every time, but as the delays are only when creating or starting, we don't think this is a big deal.

[ZFSPlugin.txt](https://github.com/TheGrandWazoo/freenas-proxmox/files/2196591/ZFSPlugin.txt)
