### PR TITLE
Update FreeNAS.pm - correction of the check whether the auth token should be used

### DIFF
--- a/perl5/PVE/Storage/LunCmd/FreeNAS.pm
+++ b/perl5/PVE/Storage/LunCmd/FreeNAS.pm
@@ -344,7 +344,7 @@ sub freenas_api_connect {
     }
     $freenas_server_list->{$apihost}->setHost($scheme . '://' . $apihost);
     $freenas_server_list->{$apihost}->addHeader('Content-Type', 'application/json');
-    if (defined($scfg->{'truenas_token_auth'})) {
+    if (defined($scfg->{'truenas_token_auth'}) && $scfg->{'truenas_token_auth'}) {
         syslog("info", (caller(0))[3] . " : Authentication using Bearer Token Auth");
         $freenas_server_list->{$apihost}->addHeader('Authorization', 'Bearer ' . $scfg->{truenas_secret});
     } else {


### PR DESCRIPTION
I had the problem that in the config storage.cfg the option “truenas_token_auth 0” is set and the check thinks I want to use token auth.

This should fix my PR for master.