### PR TITLE
Fix regex operator precedence bug in API method guard

### DIFF
--- a/perl5/PVE/Storage/LunCmd/FreeNAS.pm
+++ b/perl5/PVE/Storage/LunCmd/FreeNAS.pm
@@ -464,7 +464,7 @@ sub freenas_api_call {
     syslog("info", (caller(0))[3] . " : called for host '" . $apihost . "'");
 
     $method = uc($method);
-    if (! $method =~ /^(?>GET|DELETE|POST)$/) {
+    if ($method !~ /^(?:GET|DELETE|POST)$/) {
         syslog("info", (caller(0))[3] . " : Invalid HTTP RESTful service method '$method'");
         die "Invalid HTTP RESTful service method '$method' used.";
     }


### PR DESCRIPTION
## Summary

- `! $method =~ /pattern/` is parsed as `(! $method) =~ /pattern/` due to Perl operator precedence — the regex ran against `""` and always returned false, so any method string passed through unchecked
- Changed to `$method !~ /^(?:GET|DELETE|POST)$/` which correctly tests the method string
- Replaced atomic group `(?>...)` with non-capturing `(?:...)` since there is no backtracking concern

## Test plan

- [ ] Verify `GET`, `POST`, `DELETE` still reach the API call
- [ ] Verify an invalid method (e.g. `PUT`) is now rejected with the guard error
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)